### PR TITLE
Update gettext_i18n_rails_js.gemspec

### DIFF
--- a/gettext_i18n_rails_js.gemspec
+++ b/gettext_i18n_rails_js.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = "gettext_i18n_rails will find translations inside your .js and .coffee files, then it will create JSON versions of your .PO files and will let you serve them with the rest of your assets, thus letting you access all your translations offline from client side javascript."
   s.version = GettextI18nRailsJs::VERSION
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "Readme.md"]
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", "~> 3.2.0"
   s.add_dependency "gettext", ">= 2.3.0"


### PR DESCRIPTION
fix case typo in gemspec

linux filename is case-sensitive

otherwise following warning when install it:

```
gettext_i18n_rails_js at /home/lidaobing/.rvm/gems/ruby-1.9.3-p327/bundler/gems/gettext_i18n_rails_js-5809a5727322 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["Readme.md"] are not files
```
