### PR TITLE
Make gettext a runtime dependency

### DIFF
--- a/gettext_i18n_rails_js.gemspec
+++ b/gettext_i18n_rails_js.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 3.2.0"
   s.add_dependency "gettext_i18n_rails", ">= 0.7.1"
   s.add_dependency "po_to_json", '>= 0.0.7'
+  s.add_dependency "gettext", ">= 3.0.2"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec", "~>2"
-  s.add_development_dependency "gettext", ">= 3.0.2"
 end


### PR DESCRIPTION
Parser files both load part of the gettext library, so it appears to always
be required to load gettext_i18n_rails_js.