### PR TITLE
Avoid methods defined in rake task exposing globally

### DIFF
--- a/gettext_i18n_rails_js.gemspec
+++ b/gettext_i18n_rails_js.gemspec
@@ -68,5 +68,5 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 3.2.0"
   s.add_dependency "gettext", ">= 3.0.2"
   s.add_dependency "gettext_i18n_rails", ">= 0.7.1"
-  s.add_dependency "po_to_json", ">= 0.1.0"
+  s.add_dependency "po_to_json", ">= 1.0.0"
 end

--- a/lib/assets/javascripts/gettext/all.js
+++ b/lib/assets/javascripts/gettext/all.js
@@ -26,7 +26,7 @@
 //= require_self
 
 (function() {
-  var locales = locales || {};
+  var locales = this.locales || {};
   var locale = document.getElementsByTagName('html')[0].lang;
 
   if(!locale) {

--- a/lib/gettext_i18n_rails_js/parser/javascript.rb
+++ b/lib/gettext_i18n_rails_js/parser/javascript.rb
@@ -43,13 +43,14 @@ module GettextI18nRailsJs
       protected
 
       def collect_for(value)
-        ::File.new(
-          value
-        ).each_line.each_with_index.collect do |line, idx|
-          line.scan(invoke_regex).collect do |function, arguments|
-            yield(function, arguments, idx + 1)
+        results = ::File.open(value) do |f|
+          f.each_line.each_with_index.collect do |line, idx|
+            line.scan(invoke_regex).collect do |function, arguments|
+              yield(function, arguments, idx + 1)
+            end
           end
-        end.inject(:+).compact
+        end
+        results.empty? ? results : results.inject(:+).compact
       end
 
       def invoke_regex

--- a/lib/gettext_i18n_rails_js/task.rb
+++ b/lib/gettext_i18n_rails_js/task.rb
@@ -1,0 +1,56 @@
+require "gettext_i18n_rails/tasks"
+
+module GettextI18nRailsJs
+  module Task
+    extend self
+
+    def files_list
+      Pathname.glob(
+        ::File.join(
+          locale_path,
+          "**",
+          "*.po"
+        )
+      )
+    end
+
+    def output_path
+      ::Rails.root.join(
+        config[:output_path]
+      )
+    end
+
+    def config
+      @config ||= begin
+        file = ::Rails.root.join(
+          "config",
+          "gettext_i18n_rails_js.yml"
+        )
+
+        defaults = {
+          output_path: File.join(
+            "app",
+            "assets",
+            "javascripts",
+            "locale"
+          ),
+          handlebars_function: "__",
+          javascript_function: "__",
+          jed_options: {
+            pretty: false
+          }
+        }
+
+        if file.exist?
+          yaml = YAML.load_file(file) || {}
+
+          defaults.deep_merge(
+            yaml
+          ).with_indifferent_access
+        else
+          defaults.with_indifferent_access
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/gettext_i18n_rails_js_tasks.rake
+++ b/lib/tasks/gettext_i18n_rails_js_tasks.rake
@@ -24,20 +24,21 @@
 #
 
 require "gettext_i18n_rails/tasks"
+require "gettext_i18n_rails_js/task"
 
 namespace :gettext do
   desc "Convert PO files to JS files"
   task po_to_json: :environment do
     GettextI18nRailsJs::Parser::Javascript
-      .gettext_function = GettextI18nRailsJs::RakeTask.config[:javascript_function]
+      .gettext_function = GettextI18nRailsJs::Task.config[:javascript_function]
 
     GettextI18nRailsJs::Parser::Handlebars
-      .gettext_function = GettextI18nRailsJs::RakeTask.config[:handlebars_function]
+      .gettext_function = GettextI18nRailsJs::Task.config[:handlebars_function]
 
-    if GettextI18nRailsJs::RakeTask.files_list.empty?
+    if GettextI18nRailsJs::Task.files_list.empty?
       puts "Couldn't find PO files in #{locale_path}, run 'rake gettext:find'"
     else
-      GettextI18nRailsJs::RakeTask.files_list.each do |input|
+      GettextI18nRailsJs::Task.files_list.each do |input|
         # Language is used for filenames, while language code is used as the
         # in-app language code. So for instance, simplified chinese will live
         # in app/assets/locale/zh_CN/app.js but inside the file the language
@@ -47,14 +48,14 @@ namespace :gettext do
         language = input.dirname.basename.to_s
         language_code = language.gsub("_", "-")
 
-        destination = GettextI18nRailsJs::RakeTask.output_path.join(language)
+        destination = GettextI18nRailsJs::Task.output_path.join(language)
         destination.mkpath
 
         json = PoToJson.new(
           input.to_s
         ).generate_for_jed(
           language_code,
-          GettextI18nRailsJs::RakeTask.config[:jed_options].symbolize_keys
+          GettextI18nRailsJs::Task.config[:jed_options].symbolize_keys
         )
 
         destination.join("app.js").open("w") do |f|
@@ -75,86 +76,30 @@ namespace :gettext do
     end
   end
 
-  # Avoid methods exposing globally
-  module GettextI18nRailsJs
-    module RakeTask
-      extend self
+  # Required for gettext to filter the files
+  def files_to_translate
+    folders = [
+      "app",
+      "lib",
+      "config",
+      locale_path
+    ].join(",")
 
-      def files_list
-        Pathname.glob(
-          ::File.join(
-            locale_path,
-            "**",
-            "*.po"
-          )
-        )
-      end
+    exts = [
+      "rb",
+      "erb",
+      "haml",
+      "slim",
+      "rhtml",
+      "js",
+      "coffee",
+      "handlebars",
+      "hbs",
+      "mustache"
+    ].join(",")
 
-      def output_path
-        Rails.root.join(
-          config[:output_path]
-        )
-      end
-
-      def config
-        @config ||= begin
-          file = Rails.root.join(
-            "config",
-            "gettext_i18n_rails_js.yml"
-          )
-
-          defaults = {
-            output_path: File.join(
-              "app",
-              "assets",
-              "javascripts",
-              "locale"
-            ),
-            handlebars_function: "__",
-            javascript_function: "__",
-            jed_options: {
-              pretty: false
-            }
-          }
-
-          if file.exist?
-            yaml = YAML.load_file(file) || {}
-
-            defaults.deep_merge(
-              yaml
-            ).with_indifferent_access
-          else
-            defaults.with_indifferent_access
-          end
-        end
-      end
-
-      # Required for gettext to filter the files
-      def files_to_translate
-        folders = [
-          "app",
-          "lib",
-          "config",
-          locale_path
-        ].join(",")
-
-        exts = [
-          "rb",
-          "erb",
-          "haml",
-          "slim",
-          "rhtml",
-          "js",
-          "coffee",
-          "handlebars",
-          "hbs",
-          "mustache"
-        ].join(",")
-
-        Dir.glob(
-          "{#{folders}}/**/*.{#{exts}}"
-        )
-      end
-    end
+    Dir.glob(
+      "{#{folders}}/**/*.{#{exts}}"
+    )
   end
 end


### PR DESCRIPTION
I was using thinking-sphinx with this gem but somehow I cannot run `rake ts:rebuild` to rebuild the core index.
And later I find out it was because of the method `config` defined in `gettext:po_to_json` exposed.

It would be glad if someone could review this PR or offer a better way to deal with this issue.