### PR TITLE
Fixes exception when parsing empty js/coffee files

### DIFF
--- a/lib/gettext_i18n_rails_js/parser/javascript.rb
+++ b/lib/gettext_i18n_rails_js/parser/javascript.rb
@@ -49,7 +49,7 @@ module GettextI18nRailsJs
           line.scan(invoke_regex).collect do |function, arguments|
             yield(function, arguments, idx + 1)
           end
-        end.inject(:+).compact
+        end.inject([], :+).compact
       end
 
       def invoke_regex

--- a/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
@@ -236,6 +236,16 @@ describe GettextI18nRailsJs::Parser::Javascript do
         )
       end
     end
+
+    it "does not parse empty files" do
+      content = ""
+
+      with_file content do |path|
+        expect(parser.parse(path, [])).to(
+          eq([])
+        )
+      end
+    end
   end
 
   describe "parses javascript files" do


### PR DESCRIPTION
inject(:+) for empty files returns nil and nil has no compact method. This method has to return empty array on empty files