### PR TITLE
Remove Bundler/rubygems setup in main lib

### DIFF
--- a/lib/gettext_i18n_rails_js.rb
+++ b/lib/gettext_i18n_rails_js.rb
@@ -23,17 +23,10 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
-
-if File.exist? ENV["BUNDLE_GEMFILE"]
-  require "bundler"
-  Bundler.setup(:default)
-else
-  gem "rails", version: ">= 3.2.0"
-  gem "gettext", version: ">= 3.0.2"
-  gem "gettext_i18n_rails", version: ">= 0.7.1"
-  gem "po_to_json", version: ">= 0.1.0"
-end
+gem "rails", version: ">= 3.2.0"
+gem "gettext", version: ">= 3.0.2"
+gem "gettext_i18n_rails", version: ">= 0.7.1"
+gem "po_to_json", version: ">= 0.1.0"
 
 require "rails"
 require "gettext"

--- a/lib/gettext_i18n_rails_js/parser/base.rb
+++ b/lib/gettext_i18n_rails_js/parser/base.rb
@@ -87,9 +87,9 @@ module GettextI18nRailsJs
 
       def cleanup_value(value)
         value
-          .gsub("\n", "\n")
-          .gsub("\t", "\t")
-          .gsub("\0", "\0")
+          .tr("\n", "\n")
+          .tr("\t", "\t")
+          .tr("\0", "\0")
       end
 
       def separator_for(value)


### PR DESCRIPTION
Calling Bundler from within the library when BUNDLER_GEMFILE is set
was interfering with our app's use of Bundler and the bundler_ext gem.

Any user of this lib should already be relying on the gem specification
and/or Bundler to ensure version compatibility, so it shouldn't need to
be restated here.