### PR TITLE
feat: support .jsx files, too

### DIFF
--- a/lib/gettext_i18n_rails_js/parser/javascript.rb
+++ b/lib/gettext_i18n_rails_js/parser/javascript.rb
@@ -36,6 +36,7 @@ module GettextI18nRailsJs
       def target?(file)
         [
           ".js",
+          ".jsx",
           ".coffee"
         ].include? ::File.extname(file)
       end

--- a/lib/tasks/gettext_i18n_rails_js_tasks.rake
+++ b/lib/tasks/gettext_i18n_rails_js_tasks.rake
@@ -48,6 +48,7 @@ namespace :gettext do
       "slim",
       "rhtml",
       "js",
+      "jsx",
       "coffee",
       "handlebars",
       "hbs",


### PR DESCRIPTION
Turns out React's JSX files are parsed fine by GettextI18nRailsJs::Parser::Javascript, just needed to add them to targeted extensions list