### PR TITLE
Handlebars options

### DIFF
--- a/lib/gettext_i18n_rails_js/parser/handlebars.rb
+++ b/lib/gettext_i18n_rails_js/parser/handlebars.rb
@@ -67,8 +67,8 @@ module GettextI18nRailsJs
             ([snN]?#{gettext_function})
             \s+
             (
-              ".*?"
-              (?:\s+".*?")?
+              (["'])(?:\\?+.)*?\4
+              (?:\s+(["'])(?:\\?+.)*?\5)?
             )
             .*?
           )

--- a/lib/gettext_i18n_rails_js/parser/handlebars.rb
+++ b/lib/gettext_i18n_rails_js/parser/handlebars.rb
@@ -62,15 +62,15 @@ module GettextI18nRailsJs
         # * Remaining arguments
         # * Function call closing parenthesis
         #
-
         /
           \B[{]{2}(
             ([snN]?#{gettext_function})
             \s+
             (
               ".*?"
-              .*?
+              (?:\s+".*?")?
             )
+            .*?
           )
           [}]{2}
         /x

--- a/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
@@ -76,7 +76,7 @@ describe GettextI18nRailsJs::Parser::Handlebars do
 
     it "finds namespaced messages" do
       content = <<-EOF
-        <div>{{__ "xxxx", "yyyy"}}</div>
+        <div>{{__ "xxxx" "yyyy"}}</div>
       EOF
 
       with_file content do |path|
@@ -279,7 +279,7 @@ describe GettextI18nRailsJs::Parser::Handlebars do
         <div>
           {{gettext \"Hello {yourname}\"}}
           <span>
-            {{ngettext \"item\", \"items\", 44}}
+            {{ngettext \"item\" \"items\" 44}}
           </span>
         </div>
       EOF

--- a/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
@@ -106,6 +106,22 @@ describe GettextI18nRailsJs::Parser::Handlebars do
       end
     end
 
+    it "finds single quote messages" do
+      content = <<-EOF
+      <div>{{__ 'blah'}}</div>
+      EOF
+
+      with_file content do |path|
+        expect(parser.parse(path, [])).to(
+          eq(
+            [
+              ["blah", "#{path}:1"]
+            ]
+          )
+        )
+      end
+    end
+
     # it "finds messages with newlines/tabs" do
     #   content = <<-EOF
     #     bla = __("xxxx\n\tfoo")

--- a/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
@@ -234,6 +234,24 @@ describe GettextI18nRailsJs::Parser::Handlebars do
       end
     end
 
+    it "does not parse options" do
+      content = <<-EOF
+        <div>
+        {{__ "test with %{param}" param="something"}}
+        </div>
+      EOF
+
+      with_file content do |path|
+        expect(parser.parse(path, [])).to(
+          eq(
+            [
+              ["test with %{param}", "#{path}:1"]
+            ]
+          )
+        )
+      end
+    end
+
     # it "does not parse internal functions" do
     #   content = <<-EOF
     #     bla = n__("items (single)", "i (more)", item.count()) + __('foobar')

--- a/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
@@ -60,14 +60,14 @@ describe GettextI18nRailsJs::Parser::Handlebars do
   describe "#parse" do
     it "finds plural messages" do
       content = <<-EOF
-        <div>{{n__ "xxxx" "yyyy\" "zzzz" some_count}}</div>
+        <div>{{n__ "xxxx" "yyyy" some_count}}</div>
       EOF
 
       with_file content do |path|
         expect(parser.parse(path, [])).to(
           eq(
             [
-              ["xxxx\000yyyy\000zzzz", "#{path}:1"]
+              ["xxxx\000yyyy", "#{path}:1"]
             ]
           )
         )


### PR DESCRIPTION
This PR is fixing issue with handlebars translations with options.

e.x.:
```
{{__ "Some string with %{option}" option="test"}}`
```
That will detect as translations the `Some string with %{options}` and the `test`, but should only detect the first string.

Some other fixes: 
 * Some specs that has invalid handlebars markup
 * Implement a more strict string matching