### PR TITLE
Allow for multiline translation strings

### DIFF
--- a/lib/gettext_i18n_rails_js/parser/base.rb
+++ b/lib/gettext_i18n_rails_js/parser/base.rb
@@ -85,6 +85,11 @@ module GettextI18nRailsJs
 
       protected
 
+      def cleanup_multiline_line(value)
+        result = value.chomp
+        result.strip
+      end
+
       def cleanup_value(value)
         value
           .tr("\n", "\n")

--- a/lib/gettext_i18n_rails_js/parser/handlebars.rb
+++ b/lib/gettext_i18n_rails_js/parser/handlebars.rb
@@ -73,7 +73,7 @@ module GettextI18nRailsJs
             .*?
           )
           [}]{2}
-        /x
+        /xm
       end
     end
   end

--- a/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
@@ -150,12 +150,22 @@ describe GettextI18nRailsJs::Parser::Handlebars do
     #   end
     # end
 
-    # it "finds interpolated multi-line messages" do
-    #   content = <<-EOF
-    #     """ Parser should grab
-    #       #{ __("This") } __("known bug")
-    #     """
-    #   EOF
+    it "finds interpolated multi-line messages" do
+      content = <<-EOF
+        <div>{{{__ 'Hello, my name is <span class="name">John Doe</span>
+                    and this is a very long string'}}}</div>
+      EOF
+      with_file content do |path|
+        expect(parser.parse(path, [])).to(
+          eq(
+            [
+              ["Hello, my name is <span class=\"name\">John Doe</span>
+                    and this is a very long string", "#{path}:1"],
+            ]
+          )
+        )
+      end
+    end
 
     #   with_file content do |path|
     #     expect(parser.parse(path, [])).to(

--- a/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
@@ -191,6 +191,25 @@ describe GettextI18nRailsJs::Parser::Javascript do
       end
     end
 
+    it "finds multi-line translations" do
+      content = <<-'EOF'
+        """ Parser should grab
+        __(`Hello, my name is <span class="name">John Doe</span>
+          and this is a very long string`)
+        """
+      EOF
+
+      with_file content do |path|
+        expect(parser.parse(path, [])).to(
+          eq(
+            [
+              ["Hello, my name is <span class=\"name\">John Doe</span> and this is a very long string", "#{path}:2"]
+            ]
+          )
+        )
+      end
+    end
+
     it "does not capture a false positive" do
       content = <<-'EOF'
         bla = should_not_be_registered__("xxxx", "yyyy")


### PR DESCRIPTION
- Add /m modifier in parsers RegExp to match newline characters
- Match for multiple lines when getText opening function is found in JavaScript parser

Closes #41 