### PR TITLE
Escape quotes taking into account source quotes

### DIFF
--- a/lib/gettext_i18n_rails_js/parser/base.rb
+++ b/lib/gettext_i18n_rails_js/parser/base.rb
@@ -71,12 +71,17 @@ module GettextI18nRailsJs
       # [0]: __('foo', 'foos', 3)
       # [1]: __
       # [2]: 'foo', 'foos', 3
+      #
+      # The PO file outputs to a "" string.
+      # single quotes are unescped (if they are escaped)
+      # double quotes are escaped (if they are not already escaped)
       def parse(file, _msgids = [])
         collect_for(file) do |function, arguments, line|
           key = arguments.scan(
             /('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`)/
           ).collect do |match|
-            match.first[1..-2]
+            contents = match.first[1..-2]
+            contents.gsub(/\\'/, "'").gsub(/(?<=[^\\])"/, "\\\"")
           end.join(separator_for(function))
 
           next if key == ""

--- a/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
@@ -161,7 +161,7 @@ describe GettextI18nRailsJs::Parser::Handlebars do
         expect(parser.parse(path, [])).to(
           eq(
             [
-              ["Hello, my name is <span class=\"name\">John Doe</span>
+              ["Hello, my name is <span class=\\\"name\\\">John Doe</span>
                     and this is a very long string", "#{path}:1"],
             ]
           )

--- a/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
@@ -185,7 +185,8 @@ describe GettextI18nRailsJs::Parser::Javascript do
 
     it "finds strings that use escaped strings" do
       content = <<-'EOF'
-        __("hello \"dude\"") + __('how is it \'going\' ')
+        __("hello \"dude\"") + __('how is it \'going\' ') +
+        __('stellar "dude"') + __("it's 'going' good")
       EOF
 
       with_file content do |path|
@@ -193,7 +194,9 @@ describe GettextI18nRailsJs::Parser::Javascript do
           eq(
             [
               ["hello \\\"dude\\\"", "#{path}:1"],
-              ["how is it \\'going\\' ", "#{path}:1"]
+              ["how is it \\'going\\' ", "#{path}:1"],
+              ["stellar \"dude\"", "#{path}:2"],
+              ["it's 'going' good", "#{path}:2"]
             ]
           )
         )

--- a/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
@@ -194,8 +194,8 @@ describe GettextI18nRailsJs::Parser::Javascript do
           eq(
             [
               ["hello \\\"dude\\\"", "#{path}:1"],
-              ["how is it \\'going\\' ", "#{path}:1"],
-              ["stellar \"dude\"", "#{path}:2"],
+              ["how is it 'going' ", "#{path}:1"],
+              ["stellar \\\"dude\\\"", "#{path}:2"],
               ["it's 'going' good", "#{path}:2"]
             ]
           )
@@ -215,7 +215,7 @@ describe GettextI18nRailsJs::Parser::Javascript do
         expect(parser.parse(path, [])).to(
           eq(
             [
-              ["Hello, my name is <span class=\"name\">John Doe</span> and this is a very long string", "#{path}:2"]
+              ["Hello, my name is <span class=\\\"name\\\">John Doe</span> and this is a very long string", "#{path}:2"]
             ]
           )
         )


### PR DESCRIPTION
The strings in POT files are only expressed in double quoted strings. Luckily the double quote is escaped the same way in ruby, javascript, json, and pot, so there is no concern about that. [specification]

The strings in ruby can be expressed in single or double quoted strings. The way you escape a double quote or single quote inside those 2 formats are different.


So I'm thinking that the parsed ruby strings should be converted to look like they came from a double quoted string.

Do remember when writing `"that \\\"string\\\""` to a file looks like `that \"string\"`

[specification]: https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/PO-Files.html#PO-Files
