### PR TITLE
Autoload the parsers on first use

### DIFF
--- a/lib/gettext_i18n_rails_js/parser.rb
+++ b/lib/gettext_i18n_rails_js/parser.rb
@@ -24,11 +24,10 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-require_relative "parser/base"
-require_relative "parser/javascript"
-require_relative "parser/handlebars"
-
 module GettextI18nRailsJs
   module Parser
+    autoload(:Base, "gettext_i18n_rails_js/parser/base")
+    autoload(:Javascript, "gettext_i18n_rails_js/parser/javascript")
+    autoload(:Handlebars, "gettext_i18n_rails_js/parser/handlebars")
   end
 end


### PR DESCRIPTION
Adding this gem to an application should probably load the gettext parsing utilities when it's being used at runtime.  Currently, the gem entry lib file requires parser which eager loads these parsers and consumes time and memory when the developer or system may not need them.

### before this PR

```
% for i in $(seq 1 10); do; ruby in_line_test.rb |grep MB; done
1.828125 MB
1.9375 MB
1.796875 MB
1.546875 MB
1.890625 MB
1.546875 MB
1.8125 MB
2.40625 MB
1.9375 MB
1.6875 MB
```

### after this PR

```
% for i in $(seq 1 10); do; ruby in_line_test.rb |grep MB; done
0.90625 MB
0.53125 MB
0.984375 MB
1.1875 MB
0.46875 MB
0.390625 MB
0.453125 MB
0.96875 MB
0.546875 MB
0.5 MB
```

Using this script:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem 'gettext_i18n_rails'
  gem 'gettext', '>=3.0.2', :require => false
  # gem 'ruby_parser', :require => false, :group => :development
  # gem "gettext_i18n_rails_js", "~> 2.0", :require => false, :git => "https://github.com/jrafanie/gettext_i18n_rails_js.git", :branch => "autoload_parsers_on_first_use"
  gem "gettext_i18n_rails_js", "~> 2.0", :require => false
  gem 'derailed_benchmarks', group: :development
end

require "active_support"
require "active_support/core_ext/object/blank"
require "minitest/autorun"

require 'get_process_mem'
mem    = GetProcessMem.new
before = mem.mb

require 'gettext_i18n_rails_js'

after  = mem.mb
puts "#{after - before} MB"
```