### PR TITLE
Support rails 6.1+, ruby 2.7+ in test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.1
-          bundler: 1.17
+          ruby-version: 2.7
+          bundler: 2.4.22
           bundler-cache: true
 
       - name: Run rubocop
@@ -34,44 +34,14 @@ jobs:
 
       matrix:
         ruby:
-          - 2.1
-          - 2.5
           - 2.7
           - 3.0
           - 3.1
           - 3.2
         rails:
-          - 3.2
-          - 4.2
-          - 5.2
           - 6.1
           - 7.0
-        exclude:
-          - rails: 5.2
-            ruby: 2.1
-          - rails: 6.1
-            ruby: 2.1
-          - rails: 7.0
-            ruby: 2.1
-          - rails: 7.0
-            ruby: 2.5
-          - rails: 3.2
-            ruby: 2.7
-          - rails: 4.2
-            ruby: 2.7
-          - rails: 3.2
-            ruby: 3.0
-          - rails: 4.2
-            ruby: 3.0
-          - rails: 3.2
-            ruby: 3.1
-          - rails: 4.2
-            ruby: 3.1
-          - rails: 3.2
-            ruby: 3.2
-          - rails: 4.2
-            ruby: 3.2
-
+          - 7.1
     steps:
       - name: Checkout source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -80,7 +50,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: 1.17
+          bundler: 2.4.22
           bundler-cache: true
         env:
           RAILS_VERSION: ${{ matrix.rails }}


### PR DESCRIPTION
Rails 7 and 7.1 still support ruby 2.7 so we set this ruby as the minimum we test, keep rails 6.1 as it's not yet end of life and use bundler 2.4, which is the last version which supports ruby 2.7.