### PR TITLE
chore: Drop needless protected method

### DIFF
--- a/lib/gettext_i18n_rails_js/parser/base.rb
+++ b/lib/gettext_i18n_rails_js/parser/base.rb
@@ -97,13 +97,6 @@ module GettextI18nRailsJs
         result.strip
       end
 
-      def cleanup_value(value)
-        value
-          .tr("\n", "\n")
-          .tr("\t", "\t")
-          .tr("\0", "\0")
-      end
-
       def separator_for(value)
         if value == "n#{gettext_function}"
           "\000"
@@ -114,7 +107,7 @@ module GettextI18nRailsJs
 
       def results_for(key, file, line)
         [
-          cleanup_value(key),
+          key,
           [file, line].join(":")
         ]
       end

--- a/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
@@ -123,34 +123,6 @@ describe GettextI18nRailsJs::Parser::Handlebars do
       end
     end
 
-    # it "finds messages with newlines/tabs" do
-    #   content = <<-EOF
-    #     bla = __("xxxx\n\tfoo")
-    #   EOF
-
-    #   with_file content do |path|
-    #     expect(parser.parse(path, [])).to(
-    #       eq(
-    #         [
-    #           ["xxxx\n\tfoo", "#{path}:1"]
-    #         ]
-    #       )
-    #     )
-    #   end
-    # end
-
-    # it "finds messages with newlines/tabs (single quotes)" do
-    #   content = <<-EOF
-    #     bla = __('xxxx\n\tfoo')
-    #   EOF
-
-    #   with_file content do |path|
-    #     parser.parse(path, []).should == [
-    #       ["xxxx\n\tfoo", "#{path}:1"]
-    #     ]
-    #   end
-    # end
-
     # rubocop:disable Style/TrailingCommaInArrayLiteral
     it "finds interpolated multi-line messages" do
       content = <<-EOF


### PR DESCRIPTION
Fixes #104

cleanup_value was refactored into a method in https://github.com/webhippie/gettext_i18n_rails_js/pull/24 During that refactoring, the code was changed from this:

```
-        key.gsub!("\n", '\n')
-        key.gsub!("\t", '\t')
-        key.gsub!("\0", '\0')
```

To:

```
+      def cleanup_value(value)
+        value
+          .gsub("\n", "\n")
+          .gsub("\t", "\t")
+          .gsub("\0", "\0")
+      end
```

This resulted in a change in behavior:

```
"foo\nbar".gsub("\n", '\n') # => "foo\\nbar"
"foo\nbar".gsub("\n", "\n") # => "foo\nbar"
```

Note, the new code is basically a no-op as it's replacing the characters with the same characters.  Since no one has needed the original behavior before it's introduction 10 years ago, let's just drop this method entirely and resurrect the test: https://github.com/webhippie/gettext_i18n_rails_js/blob/master/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb#L128 if needed later on.