### PR TITLE
Revert "Autoload the parsers on first use"

### DIFF
--- a/lib/gettext_i18n_rails_js/parser.rb
+++ b/lib/gettext_i18n_rails_js/parser.rb
@@ -24,10 +24,11 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
+require_relative "parser/base"
+require_relative "parser/javascript"
+require_relative "parser/handlebars"
+
 module GettextI18nRailsJs
   module Parser
-    autoload(:Base, "gettext_i18n_rails_js/parser/base")
-    autoload(:Javascript, "gettext_i18n_rails_js/parser/javascript")
-    autoload(:Handlebars, "gettext_i18n_rails_js/parser/handlebars")
   end
 end


### PR DESCRIPTION
Hello,

This reverts #66

## Issue

Using autoload, means that Javascript and Handlebar parsers are not loaded in basic operation.
This means `GettextI18nRails add_parser` (and thus `xgettext add_parser`) are not run.

Since the parsers are not registered, running `rake gettext:find` does not know about the javascript parsers, and thus does not parse javascript files/localize them.

## Before

`rake gettext:find` does not localize strings in `js` files.

## After

`rake gettext:find` localizes strings in `js` files.

## Followup

Working with @jrafanie on a better way to both not load `gettext` into memory at runtime, and also register the handlers when running `gettext:find`. I'll try and get that PR in for you shortly.
