### PR TITLE
fix: Improve memory usage when loading the gem

### DIFF
--- a/lib/gettext_i18n_rails_js.rb
+++ b/lib/gettext_i18n_rails_js.rb
@@ -25,18 +25,13 @@
 #
 
 gem "rails", version: ">= 3.2.0"
-gem "gettext", version: ">= 3.0.2"
 gem "gettext_i18n_rails", version: ">= 0.7.1"
-gem "po_to_json", version: ">= 2.0.0"
 
 require "logger"
 require "rails"
-require "gettext"
 require "gettext_i18n_rails"
-require "po_to_json"
 
 require_relative "gettext_i18n_rails_js/version"
-require_relative "gettext_i18n_rails_js/parser"
 require_relative "gettext_i18n_rails_js/config"
 require_relative "gettext_i18n_rails_js/engine"
 

--- a/lib/tasks/gettext_i18n_rails_js_tasks.rake
+++ b/lib/tasks/gettext_i18n_rails_js_tasks.rake
@@ -24,7 +24,14 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
+gem "gettext", version: ">= 3.0.2"
+gem "po_to_json", version: ">= 2.0.0"
+
+require "gettext"
+require "po_to_json"
+
 require "gettext_i18n_rails/tasks"
+require "gettext_i18n_rails_js/parser"
 require "gettext_i18n_rails_js/task"
 
 namespace :gettext do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ if ENV.key? "CODACY_PROJECT_TOKEN"
 end
 
 require "gettext_i18n_rails_js"
+require "gettext_i18n_rails_js/parser"
 require "rspec"
 
 Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each do |file|


### PR DESCRIPTION
This is a replacement for the performance portion of #66 after the revert in #106.

This commit only loads the parsers and gettext within the rake task. This avoids loading the expensive gettext library at "runtime" when you don't need the parsing, and moves it to "build time". Note that this is also how gettext_i18n_rails does it with their slim and haml parsers ([ref](https://github.com/grosser/gettext_i18n_rails/blob/992fefa31ecf80e579a6724aca7b864a442cead3/lib/gettext_i18n_rails/tasks.rb#L40-L41))

Using the script in #66, the memory savings at runtime is reduced from ~2MB to ~0.03MB.

cc @jrafanie @kbrock 