### PR TITLE
Fix: double escaping double quotes

### DIFF
--- a/lib/gettext_i18n_rails_js/parser/base.rb
+++ b/lib/gettext_i18n_rails_js/parser/base.rb
@@ -81,7 +81,7 @@ module GettextI18nRailsJs
             /('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`)/
           ).collect do |match|
             contents = match.first[1..-2]
-            contents.gsub("\\'", "'").gsub(/(?<=[^\\])"/, "\\\"")
+            contents.gsub("\\'", "'").gsub("\\`", "`").gsub("\\\"", "\"")
           end.join(separator_for(function))
 
           next if key == ""

--- a/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/handlebars_spec.rb
@@ -133,7 +133,7 @@ describe GettextI18nRailsJs::Parser::Handlebars do
         expect(parser.parse(path, [])).to(
           eq(
             [
-              ["Hello, my name is <span class=\\\"name\\\">John Doe</span>
+              ["Hello, my name is <span class=\"name\">John Doe</span>
                     and this is a very long string", "#{path}:1"],
             ]
           )

--- a/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
+++ b/spec/gettext_i18n_rails_js/parser/javascript_spec.rb
@@ -190,9 +190,9 @@ describe GettextI18nRailsJs::Parser::Javascript do
 
       with_file content do |path|
         ret = parser.parse(path, [])
-        expect(ret[0]).to eq(["hello \\\"dude\\\"", "#{path}:1"])
-        expect(ret[1]).to eq(["how is it \\\"going\\\"", "#{path}:1"])
-        expect(ret[2]).to eq(["on this \\\"fine\\\" day", "#{path}:1"])
+        expect(ret[0]).to eq(["hello \"dude\"", "#{path}:1"])
+        expect(ret[1]).to eq(["how is it \"going\"", "#{path}:1"])
+        expect(ret[2]).to eq(["on this \"fine\" day", "#{path}:1"])
       end
     end
 
@@ -218,7 +218,7 @@ describe GettextI18nRailsJs::Parser::Javascript do
         ret = parser.parse(path, [])
         expect(ret[0]).to eq(["hello `dude`", "#{path}:1"])
         expect(ret[1]).to eq(["how is it `going`", "#{path}:1"])
-        expect(ret[2]).to eq(["on this \\`fine\\` day", "#{path}:1"]) # FIXME: this is the issue with the tests
+        expect(ret[2]).to eq(["on this `fine` day", "#{path}:1"])
       end
     end
 
@@ -234,7 +234,7 @@ describe GettextI18nRailsJs::Parser::Javascript do
         expect(parser.parse(path, [])).to(
           eq(
             [
-              ["Hello, my name is <span class=\\\"name\\\">John Doe</span> and this is a very long string", "#{path}:2"]
+              ["Hello, my name is <span class=\"name\">John Doe</span> and this is a very long string", "#{path}:2"]
             ]
           )
         )


### PR DESCRIPTION
Sorry, I introduced an issue in #55
While it fixed escaping non-double quoted strings, it now double escapes double quotes. `xgettext` already does the escaping.

This PR:

- Split apart tests to make it easier to see individual errors, adding backticks to tests.
- Fix double escaping double quotes

I'm not sure if this is considered a breaking change as the output into the POT files changes. (the quotes are changed)

Testing
=======

I created a dummy app with localized content in `.erb` and `.js` files. I ensured `rake gettext:find` produced localization for everything (thanks to #106 ) and the strings were not double escaped