### PR TITLE
refactor: Consolidate handlebar target regular expression (trivial)

### DIFF
--- a/lib/gettext_i18n_rails_js/parser/handlebars.rb
+++ b/lib/gettext_i18n_rails_js/parser/handlebars.rb
@@ -35,14 +35,7 @@ module GettextI18nRailsJs
       extend self
 
       def target?(file)
-        [
-          /\.handlebars\Z/,
-          /\.handlebars.erb\Z/,
-          /\.hbs\Z/,
-          /\.hbs.erb\Z/,
-          /\.mustache\Z/,
-          /\.mustache.erb\Z/
-        ].any? { |regexp| file.match regexp }
+        file.match(/\.(?:handlebars|hbs|mustache)(?:\.erb)?\Z/)
       end
 
       protected


### PR DESCRIPTION
Saw this and just threw it out there. If it is too small, just close

There were 3 extensions that are supported with an optional erb - so 3 x 2 = 6 regex.
Changed from 6 to a single regular expression with `(3 extensions)(optional erb)?`

There are many specs around this method, so it should fail if this introduces an error.

